### PR TITLE
[최적화]thumbnail이미지 최적화

### DIFF
--- a/ronka-mirapri-community/app/api/db/database.ts
+++ b/ronka-mirapri-community/app/api/db/database.ts
@@ -112,8 +112,16 @@ post_schema.pre("findOneAndDelete", async function (next) {
       await user.updateOne({ posts: user.posts });
     }
     const filename = post.image_url.replace(`${process.env.NEXT_PUBLIC_CDN_URL}/`, "");
-    const file = bucket.file(filename);
-    await file.delete();
+
+      // 원본 삭제
+      const file = bucket.file(filename);
+      await file.delete().catch(console.error); 
+
+      // _resized 파일 삭제
+      const resizedFilename = filename.replace(".webp", "_resized.webp");
+      const resizedFile = bucket.file(resizedFilename);
+      await resizedFile.delete().catch(console.error); 
+      
     next();
   } catch (e) {
     if (e instanceof Error) {
@@ -156,8 +164,15 @@ post_schema.pre("deleteMany", async function (next) {
         `${process.env.NEXT_PUBLIC_CDN_URL}/`,
         ""
       );
+
+      // 원본 삭제
       const file = bucket.file(filename);
-      await file.delete();
+      await file.delete().catch(console.error); 
+
+      // _resized 파일 삭제
+      const resizedFilename = filename.replace(".webp", "_resized.webp");
+      const resizedFile = bucket.file(resizedFilename);
+      await resizedFile.delete().catch(console.error); 
     }
     await Promise.all([...promise_delete_likes, ...promise_update_user]);
     next();

--- a/ronka-mirapri-community/app/api/image/route.ts
+++ b/ronka-mirapri-community/app/api/image/route.ts
@@ -14,40 +14,44 @@ export async function POST(request: NextRequest) {
   const formdata = await request.formData();
   const file = formdata.get("image");
 
-  const options: Intl.DateTimeFormatOptions = {
-    month: "2-digit", // 두 자리 월
-    day: "2-digit", // 두 자리 일
-    hour: "2-digit", // 두 자리 시간
-    minute: "2-digit", // 두 자리 분
-    hour12: false, // 24시간제
-    timeZone: "Asia/Seoul", // 한국 시간대
-  };
+  if (!(file instanceof Blob)) return NextResponse.json({ success: false });
 
-  if (file instanceof Blob) {
-    const buffer = await file.arrayBuffer();
+  const buffer = await file.arrayBuffer();
+  const nodeBuffer = Buffer.from(buffer);
 
     try {
-      const webpBuffer = await sharp(Buffer.from(buffer))
-      .resize(350, 700, {
-        fit: 'cover',  
-        position: 'center' 
-      })
-      .webp({quality: 80})
+      const formattedDate = new Intl.DateTimeFormat("ko-KR", {
+      month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit",
+      hour12: false, timeZone: "Asia/Seoul",
+    }).format(new Date()).replace(/\D/g, "");
+
+    const baseName = `${generateUUID()}-${formattedDate}`;
+    const filename = `${baseName}.webp`;
+    const resizedFilename = `${baseName}_resized.webp`;
+
+    // 1. 원본(고화질) 생성
+    const originalBuffer = await sharp(nodeBuffer)
+      .resize({ width: 1080 }) // 너비 1080으로 제한 (비율 유지)
+      .webp({ quality: 30 })
       .toBuffer();
 
-      const formattedDate = new Intl.DateTimeFormat("ko-KR", options)
-        .format(new Date())
-        .replace(/\D/g, "");
+    // 2. 디스플레이용(255x510) 생성
+    const resizedBuffer = await sharp(nodeBuffer)
+      .resize(255, 510, { fit: 'fill' })
+      .webp({ quality: 90 })
+      .toBuffer();
 
-      const filename = `${generateUUID()}-${formattedDate}.webp`;
-      const upload = bucket.file(filename);
-
-      await upload.save(webpBuffer, {
+    // 3. 병렬 업로드 (Promise.all로 속도 향상)
+    await Promise.all([
+      bucket.file(filename).save(originalBuffer, {
         contentType: "image/webp",
-        metadata: {
-          cacheControl: "public, max-age=31536000",
-        },
-      });
+        metadata: { cacheControl: "public, max-age=31536000" },
+      }),
+      bucket.file(resizedFilename).save(resizedBuffer, {
+        contentType: "image/webp",
+        metadata: { cacheControl: "public, max-age=31536000" },
+      })
+    ]);
       
       const image_url = `${process.env.NEXT_PUBLIC_CDN_URL}/${filename}`;
       return NextResponse.json({ success: true, image_url: image_url });
@@ -56,5 +60,4 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ success: false, error: e.message || "Unknown Error" });
     }
   }
-  return NextResponse.json({ success: false });
-}
+ 

--- a/ronka-mirapri-community/app/api/migrate-all/route.ts
+++ b/ronka-mirapri-community/app/api/migrate-all/route.ts
@@ -1,5 +1,5 @@
 // 전체 이미지 마이그레이션을 위한 코드
-// 현재 적용되어있는 마이그레이션 내용은 350*700으로 이미지 리사이징
+// 현재 적용되어있는 마이그레이션 내용은 255*510으로 이미지 리사이징 버전 생성(_resized)
 // localhost:3000의 콘솔에 이 스크립트를 실행하면 작동됩니다.
 
 // async function startResizing() {
@@ -32,8 +32,8 @@ import { Storage } from "@google-cloud/storage";
 import sharp from "sharp";
 import { NextRequest, NextResponse } from "next/server";
 
-const TARGET_WIDTH = 350;
-const TARGET_HEIGHT = 700;
+const TARGET_WIDTH = 255;
+const TARGET_HEIGHT = 510;
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -48,37 +48,39 @@ export async function GET(request: NextRequest) {
 
   try {
     const [allFiles] = await bucket.getFiles();
-    const targetFiles = allFiles.slice(start, start + limit);
+    const originalFiles = allFiles.filter(file => 
+      /\.webp$/i.test(file.name) && !file.name.includes("_resized")
+    );
+    
+    const targetFiles = originalFiles.slice(start, start + limit);
     
     const results = {
       processed: 0,
-      resized: 0,
+      created: 0,
       skipped: 0,
       errors: [] as string[],
-      nextStart: (start + limit < allFiles.length) ? (start + limit) : null,
-      totalFiles: allFiles.length
+      nextStart: (start + limit < originalFiles.length) ? (start + limit) : null,
+      totalOriginalFiles: originalFiles.length
     };
 
     for (const file of targetFiles) {
       results.processed++;
 
-      // webp 파일만 대상으로 처리
-      if (!/\.webp$/i.test(file.name)) {
-        results.skipped++;
-        continue;
-      }
+      // 새로 만들 파일명 정의 (예: image.webp -> image_resized.webp)
+      const newFileName = file.name.replace(".webp", "_resized.webp");
 
       try {
-        const [content] = await file.download();
-        const metadata = await sharp(content).metadata();
-
-        // 이미 목표 사이즈보다 작거나 같으면 변환 건너뜀 (중복 작업 방지)
-        if (metadata.width === TARGET_WIDTH && metadata.height === TARGET_HEIGHT) {
+        // 이미 해당 리사이즈 파일이 존재하는지 체크 (선택 사항, 중복 실행 방지)
+        const newFile = bucket.file(newFileName);
+        const [exists] = await newFile.exists();
+        if (exists) {
           results.skipped++;
           continue;
         }
 
-        // 리사이징 수행
+        const [content] = await file.download();
+
+        // 리사이징 수행 
         const resizedBuffer = await sharp(content)
           .resize(TARGET_WIDTH, TARGET_HEIGHT, {
             fit: "fill", 
@@ -86,7 +88,8 @@ export async function GET(request: NextRequest) {
           .webp({ quality: 90 }) 
           .toBuffer();
 
-        await file.save(resizedBuffer, {
+        // 새로운 이름으로 저장
+        await newFile.save(resizedBuffer, {
           contentType: "image/webp",
           resumable: false,
           metadata: {
@@ -94,7 +97,7 @@ export async function GET(request: NextRequest) {
           }
         });
 
-        results.resized++;
+        results.created++;
       } catch (err: any) {
         results.errors.push(`${file.name}: ${err.message}`);
       }
@@ -103,7 +106,7 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       success: true,
       ...results,
-      message: `${start}부터 ${start + results.processed}까지 처리 완료 (전체: ${allFiles.length})`
+      message: `${start}부터 ${start + results.processed}까지 처리 완료 (대상: ${originalFiles.length})`
     });
 
   } catch (error: any) {

--- a/ronka-mirapri-community/app/components/PostThumbnail.tsx
+++ b/ronka-mirapri-community/app/components/PostThumbnail.tsx
@@ -68,11 +68,13 @@ export default function PostThumbnail({
     router.push(`/post/${post.index}`);
   };
 
+  const resizedUrl = post.image_url.replace(".webp", "_resized.webp");
+
   return (
     <div className="post-box">
       <Image
         className="post-thumbnail"
-        src={post.image_url}
+        src={resizedUrl}
         alt={post.title}
         onClick={post_click_handler}
         fill={true}


### PR DESCRIPTION
2가지 용도별 이미지를 구분하여 생성하고 상황에 맞춰서 사용하게끔 변경
또한, 삭제될때도 resized 이미지가 함께 제거되도록 기능추가

- 내부 및 이미지 생성용 이미지(원본)는 1080사이즈, 퀄리티 30의 webp
- 갤러리 화면에서 보이는 이미지(resized)는 510사이즈, 퀄리티 90의 webp